### PR TITLE
Tweak comment creation

### DIFF
--- a/changelog/104.trivial.md
+++ b/changelog/104.trivial.md
@@ -1,0 +1,2 @@
+Fixed the auto-generated GitHub comment generation.
+It will now work, even if the merge request only performs create/delete operations.

--- a/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/create-database-diff-comment.py
+++ b/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/create-database-diff-comment.py
@@ -39,7 +39,8 @@ If supplied, we use this to provide a clearer message about which diff we're loo
     )
 
     with open(out_file, "w") as fh:
-        fh.write(changes_comment)
+        # Ensure newline at end of file
+        fh.write(f"{changes_comment}\n")
 
 
 if __name__ == "__main__":

--- a/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/db_changes.py
+++ b/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/db_changes.py
@@ -101,34 +101,23 @@ def diff_db_to_changes_comment(
         lambda x: x.split(",")[0]
     )
 
-    if all(
-        c in diffs_incl_source_id
-        for c in [
-            "attribute_changed",
-            "old_value",
-            "new_value",
-        ]
-    ):
-        summary_table = diffs_incl_source_id[
-            [
-                "source_id",
-                "operation",
+    summary_table_columns = [
+        "source_id",
+        "operation",
+        *[
+            c
+            for c in [
                 "attribute_changed",
                 "old_value",
                 "new_value",
             ]
-        ]
-
-    else:
-        summary_table = diffs_incl_source_id[
-            [
-                "source_id",
-                "operation",
-            ]
-        ]
+            if c in diffs_incl_source_id
+        ],
+    ]
 
     summary_table = (
-        summary_table.fillna("None")
+        diffs_incl_source_id[summary_table_columns]
+        .fillna("None")
         .value_counts(dropna=False)
         .sort_values(ascending=False)
         .to_frame()

--- a/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/db_changes.py
+++ b/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/db_changes.py
@@ -101,8 +101,15 @@ def diff_db_to_changes_comment(
         lambda x: x.split(",")[0]
     )
 
-    summary_table = (
-        diffs_incl_source_id[
+    if all(
+        c in diffs_incl_source_id
+        for c in [
+            "attribute_changed",
+            "old_value",
+            "new_value",
+        ]
+    ):
+        summary_table = diffs_incl_source_id[
             [
                 "source_id",
                 "operation",
@@ -111,7 +118,17 @@ def diff_db_to_changes_comment(
                 "new_value",
             ]
         ]
-        .fillna("None")
+
+    else:
+        summary_table = diffs_incl_source_id[
+            [
+                "source_id",
+                "operation",
+            ]
+        ]
+
+    summary_table = (
+        summary_table.fillna("None")
         .value_counts(dropna=False)
         .sort_values(ascending=False)
         .to_frame()


### PR DESCRIPTION
## Description

Makes comment creation more robust.
It will now also work even if there are only create/delete
operations from a MR.

## Checklist

Please confirm that this pull request has done the following:

- [ ] (N/A) Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
