### PR TITLE
Move ESGF scrape to GitHub actions

### DIFF
--- a/.github/workflows/udpate-esgf-scrape.yaml
+++ b/.github/workflows/udpate-esgf-scrape.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [auto-scrape-esgf]
   workflow_dispatch:
+  # TODO: turn on before merging
   # schedule:
   #   # * is a special character in YAML so you have to quote this string
   #   # This means every day at 10:00.
@@ -41,6 +42,8 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           python python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-database.py --repo-root-dir .
+          python python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-html-pages.py --repo-root-dir .
+          mkdocs build
 
           TIMESTAMP=$(date +%Y-%m-%dT%H-%M-%S)
           BRANCH_NAME="${TIMESTAMP}_esgf-input4mips-json-update"
@@ -52,5 +55,4 @@ jobs:
           git checkout -b "${BRANCH_NAME}"
           git commit -m "Update ESGF input4MIPs JSON file"
           git push --set-upstream origin "${BRANCH_NAME}"
-          gh pr create --title "Bot: ${TIMESTAMP} update ESGF JSON" --body "Created from update-esgf-scrape action" --label "esgf-json-update" --reviewer znichollscr
-          # gh pr create --title "Bot: ${TIMESTAMP} update ESGF JSON" --body "Created from nimbus bot" --label "esgf-json-update" --reviewer znichollscr --reviewer durack1
+          gh pr create --title "Bot: ${TIMESTAMP} update ESGF JSON" --body "Created from update-esgf-scrape action" --label "esgf-json-update" --reviewer znichollscr --reviewer durack1

--- a/.github/workflows/udpate-esgf-scrape.yaml
+++ b/.github/workflows/udpate-esgf-scrape.yaml
@@ -1,0 +1,50 @@
+name: Update ESGF scrape
+
+on:
+  push:
+    branches: [auto-scrape-esgf]
+  workflow_dispatch:
+  # schedule:
+  #   # * is a special character in YAML so you have to quote this string
+  #   # This means every day at 10:00.
+  #   # see https://crontab.guru/#0_10_*_*_*
+  #   - cron:  '0 10 * * *'
+
+jobs:
+  update-esgf-scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Scrape ESGF
+        run: |
+          which pip
+          pip install python-packages/input4MIPs-CVs
+          python python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-esgf-scrape.py --out-file Database/input-data/esgf-input4MIPs.json --n-threads 4
+
+      - name: Create new MR if needed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          git add Database/input-data/esgf-input4MIPs.json
+          git diff-index --cached --quiet HEAD
+          if [ $? -eq 0 ]; then
+            echo "No changes after grabbing the latest scrape"
+            exit 0
+          fi
+
+          TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+          BRANCH_NAME="${TIMESTAMP}_esgf-input4mips-json-update"
+          echo ${TIMESTAMP}
+          echo ${BRANCH_NAME}
+          git checkout -b "${BRANCH_NAME}"
+          git commit -m "Update ESGF input4MIPs JSON file"
+          git push --set-upstream origin "${BRANCH_NAME}"
+          gh pr create --title "Bot: ${TIMESTAMP} update ESGF JSON" --body "Created from update-esgf-scrape action" --label "esgf-json-update" --reviewer znichollscr
+          # gh pr create --title "Bot: ${TIMESTAMP} update ESGF JSON" --body "Created from nimbus bot" --label "esgf-json-update" --reviewer znichollscr --reviewer durack1

--- a/.github/workflows/udpate-esgf-scrape.yaml
+++ b/.github/workflows/udpate-esgf-scrape.yaml
@@ -27,22 +27,27 @@ jobs:
           pip install python-packages/input4MIPs-CVs
           python python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-esgf-scrape.py --out-file Database/input-data/esgf-input4MIPs.json --n-threads 4
 
+      - name: Check if scrape was updated
+        uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20
+        id: verify-changed-files
+        with:
+          files: Database/input-data/esgf-input4MIPs.json
+
       - name: Create new MR if needed
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
         env:
+          CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          git add Database/input-data/esgf-input4MIPs.json
-          git diff-index --cached --quiet HEAD
-          if [ $? -eq 0 ]; then
-            echo "No changes after grabbing the latest scrape"
-            exit 0
-          fi
+          echo "Changed files: $CHANGED_FILES"
+          git status
 
           TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
           BRANCH_NAME="${TIMESTAMP}_esgf-input4mips-json-update"
           echo ${TIMESTAMP}
           echo ${BRANCH_NAME}
+          git add Database/input-data/esgf-input4MIPs.json
           git checkout -b "${BRANCH_NAME}"
           git commit -m "Update ESGF input4MIPs JSON file"
           git push --set-upstream origin "${BRANCH_NAME}"

--- a/.github/workflows/udpate-esgf-scrape.yaml
+++ b/.github/workflows/udpate-esgf-scrape.yaml
@@ -40,13 +40,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+          python python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-database.py --repo-root-dir .
+
+          TIMESTAMP=$(date +%Y-%m-%dT%H-%M-%S)
           BRANCH_NAME="${TIMESTAMP}_esgf-input4mips-json-update"
 
           git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "$CI_COMMIT_EMAIL"
 
-          git add Database/input-data/esgf-input4MIPs.json
+          git add .
           git checkout -b "${BRANCH_NAME}"
           git commit -m "Update ESGF input4MIPs JSON file"
           git push --set-upstream origin "${BRANCH_NAME}"

--- a/.github/workflows/udpate-esgf-scrape.yaml
+++ b/.github/workflows/udpate-esgf-scrape.yaml
@@ -40,13 +40,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          echo "Changed files: $CHANGED_FILES"
-          git status
-
           TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
           BRANCH_NAME="${TIMESTAMP}_esgf-input4mips-json-update"
-          echo ${TIMESTAMP}
-          echo ${BRANCH_NAME}
+
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$CI_COMMIT_EMAIL"
+
           git add Database/input-data/esgf-input4MIPs.json
           git checkout -b "${BRANCH_NAME}"
           git commit -m "Update ESGF input4MIPs JSON file"

--- a/.github/workflows/udpate-esgf-scrape.yaml
+++ b/.github/workflows/udpate-esgf-scrape.yaml
@@ -1,8 +1,8 @@
 name: Update ESGF scrape
 
 on:
-  push:
-    branches: [auto-scrape-esgf]
+  # push:
+  #   branches: [auto-scrape-esgf]
   workflow_dispatch:
   # TODO: turn on before merging
   # schedule:

--- a/.github/workflows/update-esgf-scrape.yaml
+++ b/.github/workflows/update-esgf-scrape.yaml
@@ -42,8 +42,9 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           python python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-database.py --repo-root-dir .
-          python python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-html-pages.py --repo-root-dir .
-          mkdocs build
+          # Leave off for now as can fail
+          # python python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-html-pages.py --repo-root-dir .
+          # mkdocs build
 
           TIMESTAMP=$(date +%Y-%m-%dT%H-%M-%S)
           BRANCH_NAME="${TIMESTAMP}_esgf-input4mips-json-update"

--- a/.github/workflows/update-esgf-scrape.yaml
+++ b/.github/workflows/update-esgf-scrape.yaml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # This means every day at 10:00.
-    # see https://crontab.guru/#0_10_*_*_*
-    - cron:  '0 10 * * *'
+    # This means every six hours,
+    # see https://crontab.guru/every-6-hours
+    - cron:  '0 */6 * * *'
 
 jobs:
   update-esgf-scrape:

--- a/.github/workflows/update-esgf-scrape.yaml
+++ b/.github/workflows/update-esgf-scrape.yaml
@@ -4,12 +4,11 @@ on:
   # push:
   #   branches: [auto-scrape-esgf]
   workflow_dispatch:
-  # TODO: turn on before merging
-  # schedule:
-  #   # * is a special character in YAML so you have to quote this string
-  #   # This means every day at 10:00.
-  #   # see https://crontab.guru/#0_10_*_*_*
-  #   - cron:  '0 10 * * *'
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # This means every day at 10:00.
+    # see https://crontab.guru/#0_10_*_*_*
+    - cron:  '0 10 * * *'
 
 jobs:
   update-esgf-scrape:

--- a/changelog/276.trivial.md
+++ b/changelog/276.trivial.md
@@ -1,0 +1,1 @@
+Added a GitHub action to automate the scrape from ESGF

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,25 +23,15 @@ In `Database/input-data` there are three components:
 
 `Database/input-data/esgf-input4MIPs.json` is a scrape of information from the ESGF index.
 This captures the latest set of information we have queried from the ESGF index database.
-It is generated with `scripts/pollESGF.py` (the process is auto-run every 6-hrs on perlmutter).
-We hope to switch to automated generation of this file in the future
-(see [#69](https://github.com/PCMDI/input4MIPs_CVs/issues/69)).
+It is generated via a GitHub action that automatically creates pull requests if new files have been published.
+If you need to run it manually, you can run it with the steps below:
 
-If running on perlmutter, to update this file, simply copy the latest output into this repository.
-On perlmutter, the command is:
-
-```sh
-cp /global/cfs/projectdirs/m4931/gsharing/user_pub_work/input4MIPs/input4MIPs/esgf-input4MIPs.json Database/input-data/esgf-input4MIPs.json
-```
-
-To update the file locally, simply run the script.
-you may need to have an environment activated with needed dependencies
-(e.g. `requests` before you can run this).
-The command is:
-
-```sh
-python scripts/pollESGF.py Database/input-data/esgf-input4MIPs.json
-```
+1. Make a virtual environment (e.g. `python3 -m venv venv`)
+2. Activate the virtual environment 
+   (e.g. `source venv/bin/activate` - be careful not to activate multiple envs at once!)
+3. Install the requirements into the environment
+   (e.g. `pip install -r dev-requirements.txt`)
+4. Run the script e.g. `python python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-esgf-scrape.py --out-file Database/input-data/esgf-input4MIPs.json --n-threads 4`
 
 `Database/input-data/pmount` contains a number of JSON files.
 Each file contains information about one file
@@ -64,7 +54,8 @@ At present, we are tracking all of these inputs as part of this repository.
 This is ok for now, as the data is relatively small.
 This may not scale, so if we get to a certain size, we may have to pick a different approach.
 
-The data from these three inputs, plus information from the Controlled Vocabularies (CVs),
+The data from these three inputs,
+plus information from the Controlled Vocabularies (CVs),
 gets combined to create `Database/input4MIPs_db_file_entries.json`.
 This combination is done using `python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-database.py`.
 In order to run this script, you should:

--- a/python-packages/input4MIPs-CVs/pyproject.toml
+++ b/python-packages/input4MIPs-CVs/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pandas==2.2.2",
     "pandas_diff==1.4.7",
     "pyyaml==6.0.2",
+    "requests==2.32.3",
     "tqdm==4.66.4",
     "typer==0.12.3",
 ]

--- a/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-esgf-scrape.py
+++ b/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-esgf-scrape.py
@@ -45,11 +45,14 @@ def get_esgf_info(n_threads: int) -> dict[str, Any]:
         **COMMON_PARAMS,
         limit=0,
         facets="source_id",
+    )
+    print(f"Pinging {url=} with {params=}")
+    r_source_ids = requests.get(
+        url,
+        params=params,
         # Long timeout just in case
         timeout=100,
     )
-    print(f"Pinging {url=} with {params=}")
-    r_source_ids = requests.get(url, params=params)
     r_source_ids.raise_for_status()
 
     source_ids = []

--- a/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-esgf-scrape.py
+++ b/python-packages/input4MIPs-CVs/src/input4MIPs_CVs/cli/update-esgf-scrape.py
@@ -1,0 +1,116 @@
+"""
+Update our scrape of the ESGF index
+"""
+
+from __future__ import annotations
+
+import json
+from functools import partial
+from pathlib import Path
+from typing import Annotated, Any
+
+import requests
+import requests.adapters
+import typer
+from tqdm.contrib.concurrent import thread_map
+
+COMMON_PARAMS = dict(
+    replica=False,
+    activity_id="input4MIPs",
+    type="Dataset",
+)
+
+
+def get_source_id_result(
+    source_id: str, session: requests.Session
+) -> requests.models.Response:
+    url = "https://esgf-node.ornl.gov/esgf-1-5-bridge"
+    params = dict(
+        # hacky, but whatever
+        **COMMON_PARAMS,
+        limit=10_000,
+        facets="source_id",
+        source_id=source_id,
+    )
+    # print(f"Pinging {url=} with {params=}")
+    r_source_id = session.get(url, params=params)
+
+    return r_source_id
+
+
+def get_esgf_info(n_threads: int) -> dict[str, Any]:
+    url = "https://esgf-node.ornl.gov/esgf-1-5-bridge"
+    params = dict(
+        # hacky, but whatever
+        **COMMON_PARAMS,
+        limit=0,
+        facets="source_id",
+        # Long timeout just in case
+        timeout=100,
+    )
+    print(f"Pinging {url=} with {params=}")
+    r_source_ids = requests.get(url, params=params)
+    r_source_ids.raise_for_status()
+
+    source_ids = []
+    for source_id, n_results_str in zip(
+        r_source_ids.json()["facet_counts"]["facet_fields"]["source_id"][::2],
+        r_source_ids.json()["facet_counts"]["facet_fields"]["source_id"][1::2],
+    ):
+        n_results = int(n_results_str)
+        if n_results > 10_000:
+            msg = f"The API is limited to returning 10 000 results, but {source_id} has {n_results}"
+            raise AssertionError(msg)
+
+        source_ids.append(source_id)
+
+    session = requests.Session()
+    retries = requests.adapters.Retry(
+        # Just in case flaky
+        total=10,
+        backoff_factor=0.1,
+        status_forcelist=[429],
+    )
+    session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
+
+    search_results = thread_map(
+        partial(get_source_id_result, session=session),
+        source_ids,
+        max_workers=n_threads,
+    )
+    res = {}
+    for sr in search_results:
+        sr.raise_for_status()
+        sr_json = sr.json()
+        for ds in sr_json["response"]["docs"]:
+            res[ds["instance_id"]] = ds
+
+    return res
+
+
+def main(
+    out_file: Annotated[Path, typer.Option(help="File in which to write the result")],
+    n_threads: Annotated[
+        int, typer.Option(help="Number of parallel threads to use")
+    ] = 8,
+) -> None:
+    """
+    Scrape information from ESGF
+    """
+    esgf_info = get_esgf_info(n_threads=n_threads)
+
+    with open(out_file, "w") as fh:
+        json.dump(
+            esgf_info,
+            fh,
+            ensure_ascii=True,
+            sort_keys=True,
+            indent=4,
+            separators=(",", ":"),
+        )
+
+    print(f"Wrote {out_file}")
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
## Description

Move ESGF scrape to GitHub actions

An example of the PRs it creates: https://github.com/PCMDI/input4MIPs_CVs/pull/267

Fix #115 

## Checklist

Please confirm that this pull request has done the following:

- [ ] ~Data released on ESGF~
- [ ] ~ESGF update pulled in here~
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
- [ ] Did a new release after merging
