### PR TITLE
Revised population density (historical and projections)

### DIFF
--- a/CVs/input4MIPs_source_id.json
+++ b/CVs/input4MIPs_source_id.json
@@ -2079,6 +2079,517 @@
         "mip_era":"CMIP6Plus",
         "source_version":"0.1.0"
     },
+        "PIK-h-0-2-0":{
+        "activity_id":"input4MIPs",
+        "authors":[
+            {
+                "affiliations":[
+                    "Research Department Transformation Pathways, Potsdam Institute for Climate Impact Research (PIK), Member of the Leibniz Association, Potsdam, Germany",
+                    "Institute of Marine and Environmental Sciences, University of Szczecin, Szczecin, Poland"
+                ],
+                "email":"dominik.paprotny@pik-potsdam.de",
+                "name":"Dominik Paprotny",
+                "orcid":"0000-0001-5090-8402"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"laurence.hawker@bristol.ac.uk",
+                "name":"Laurence Hawker",
+                "orcid":"0000-0002-8317-7084"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"M.Bondarenko@soton.ac.uk",
+                "name":"Maksym Bondarenko",
+                "orcid":"0000-0003-4958-6551"
+            },
+            {
+                "affiliations":[
+                    "Department of Social Statistics and Demography, University of Southampton, UK"
+                ],
+                "email":"J.D.Hilton@soton.ac.uk",
+                "name":"Jason Hilton",
+                "orcid":"0000-0001-9473-757X"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"n.tejedor-garavito@soton.ac.uk",
+                "name":"Natalia Tejedor Garavito",
+                "orcid":"0000-0002-1140-6263"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"evgeny.noi@bristol.ac.uk",
+                "name":"Evgeny Noi",
+                "orcid":"0000-0002-7914-1548"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"A.J.Tatem@soton.ac.uk",
+                "name":"Andrew Tatem",
+                "orcid":"0000-0002-7270-941X"
+            }
+        ],
+        "contact":"Dominik Paprotny (dominik.paprotny@pik-potsdam.de); Laurence Hawker (laurence.hawker@bristol.ac.uk)",
+        "dataset_category":[
+            "population"
+        ],
+        "further_info_url":"https://github.com/HORIZON-COMPASS/Exposure-and-vulnerability-modelling",
+        "institution_id":"PIK",
+        "license_id":"CC BY 4.0",
+        "mip_era":"CMIP6Plus",
+        "source_version":"0.2.0"
+    },
+    "PIK-hl-0-2-0":{
+        "activity_id":"input4MIPs",
+        "authors":[
+            {
+                "affiliations":[
+                    "Research Department Transformation Pathways, Potsdam Institute for Climate Impact Research (PIK), Member of the Leibniz Association, Potsdam, Germany",
+                    "Institute of Marine and Environmental Sciences, University of Szczecin, Szczecin, Poland"
+                ],
+                "email":"dominik.paprotny@pik-potsdam.de",
+                "name":"Dominik Paprotny",
+                "orcid":"0000-0001-5090-8402"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"laurence.hawker@bristol.ac.uk",
+                "name":"Laurence Hawker",
+                "orcid":"0000-0002-8317-7084"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"M.Bondarenko@soton.ac.uk",
+                "name":"Maksym Bondarenko",
+                "orcid":"0000-0003-4958-6551"
+            },
+            {
+                "affiliations":[
+                    "Department of Social Statistics and Demography, University of Southampton, UK"
+                ],
+                "email":"J.D.Hilton@soton.ac.uk",
+                "name":"Jason Hilton",
+                "orcid":"0000-0001-9473-757X"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"n.tejedor-garavito@soton.ac.uk",
+                "name":"Natalia Tejedor Garavito",
+                "orcid":"0000-0002-1140-6263"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"evgeny.noi@bristol.ac.uk",
+                "name":"Evgeny Noi",
+                "orcid":"0000-0002-7914-1548"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"A.J.Tatem@soton.ac.uk",
+                "name":"Andrew Tatem",
+                "orcid":"0000-0002-7270-941X"
+            }
+        ],
+        "contact":"Dominik Paprotny (dominik.paprotny@pik-potsdam.de); Laurence Hawker (laurence.hawker@bristol.ac.uk)",
+        "dataset_category":[
+            "population"
+        ],
+        "further_info_url":"https://github.com/HORIZON-COMPASS/Exposure-and-vulnerability-modelling",
+        "institution_id":"PIK",
+        "license_id":"CC BY 4.0",
+        "mip_era":"CMIP6Plus",
+        "source_version":"0.2.0"
+    },
+    "PIK-m-0-2-0":{
+        "activity_id":"input4MIPs",
+        "authors":[
+            {
+                "affiliations":[
+                    "Research Department Transformation Pathways, Potsdam Institute for Climate Impact Research (PIK), Member of the Leibniz Association, Potsdam, Germany",
+                    "Institute of Marine and Environmental Sciences, University of Szczecin, Szczecin, Poland"
+                ],
+                "email":"dominik.paprotny@pik-potsdam.de",
+                "name":"Dominik Paprotny",
+                "orcid":"0000-0001-5090-8402"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"laurence.hawker@bristol.ac.uk",
+                "name":"Laurence Hawker",
+                "orcid":"0000-0002-8317-7084"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"M.Bondarenko@soton.ac.uk",
+                "name":"Maksym Bondarenko",
+                "orcid":"0000-0003-4958-6551"
+            },
+            {
+                "affiliations":[
+                    "Department of Social Statistics and Demography, University of Southampton, UK"
+                ],
+                "email":"J.D.Hilton@soton.ac.uk",
+                "name":"Jason Hilton",
+                "orcid":"0000-0001-9473-757X"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"n.tejedor-garavito@soton.ac.uk",
+                "name":"Natalia Tejedor Garavito",
+                "orcid":"0000-0002-1140-6263"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"evgeny.noi@bristol.ac.uk",
+                "name":"Evgeny Noi",
+                "orcid":"0000-0002-7914-1548"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"A.J.Tatem@soton.ac.uk",
+                "name":"Andrew Tatem",
+                "orcid":"0000-0002-7270-941X"
+            }
+        ],
+        "contact":"Dominik Paprotny (dominik.paprotny@pik-potsdam.de); Laurence Hawker (laurence.hawker@bristol.ac.uk)",
+        "dataset_category":[
+            "population"
+        ],
+        "further_info_url":"https://github.com/HORIZON-COMPASS/Exposure-and-vulnerability-modelling",
+        "institution_id":"PIK",
+        "license_id":"CC BY 4.0",
+        "mip_era":"CMIP6Plus",
+        "source_version":"0.2.0"
+    },
+    "PIK-ml-0-2-0":{
+        "activity_id":"input4MIPs",
+        "authors":[
+            {
+                "affiliations":[
+                    "Research Department Transformation Pathways, Potsdam Institute for Climate Impact Research (PIK), Member of the Leibniz Association, Potsdam, Germany",
+                    "Institute of Marine and Environmental Sciences, University of Szczecin, Szczecin, Poland"
+                ],
+                "email":"dominik.paprotny@pik-potsdam.de",
+                "name":"Dominik Paprotny",
+                "orcid":"0000-0001-5090-8402"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"laurence.hawker@bristol.ac.uk",
+                "name":"Laurence Hawker",
+                "orcid":"0000-0002-8317-7084"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"M.Bondarenko@soton.ac.uk",
+                "name":"Maksym Bondarenko",
+                "orcid":"0000-0003-4958-6551"
+            },
+            {
+                "affiliations":[
+                    "Department of Social Statistics and Demography, University of Southampton, UK"
+                ],
+                "email":"J.D.Hilton@soton.ac.uk",
+                "name":"Jason Hilton",
+                "orcid":"0000-0001-9473-757X"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"n.tejedor-garavito@soton.ac.uk",
+                "name":"Natalia Tejedor Garavito",
+                "orcid":"0000-0002-1140-6263"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"evgeny.noi@bristol.ac.uk",
+                "name":"Evgeny Noi",
+                "orcid":"0000-0002-7914-1548"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"A.J.Tatem@soton.ac.uk",
+                "name":"Andrew Tatem",
+                "orcid":"0000-0002-7270-941X"
+            }
+        ],
+        "contact":"Dominik Paprotny (dominik.paprotny@pik-potsdam.de); Laurence Hawker (laurence.hawker@bristol.ac.uk)",
+        "dataset_category":[
+            "population"
+        ],
+        "further_info_url":"https://github.com/HORIZON-COMPASS/Exposure-and-vulnerability-modelling",
+        "institution_id":"PIK",
+        "license_id":"CC BY 4.0",
+        "mip_era":"CMIP6Plus",
+        "source_version":"0.2.0"
+    },
+    "PIK-l-0-2-0":{
+        "activity_id":"input4MIPs",
+        "authors":[
+            {
+                "affiliations":[
+                    "Research Department Transformation Pathways, Potsdam Institute for Climate Impact Research (PIK), Member of the Leibniz Association, Potsdam, Germany",
+                    "Institute of Marine and Environmental Sciences, University of Szczecin, Szczecin, Poland"
+                ],
+                "email":"dominik.paprotny@pik-potsdam.de",
+                "name":"Dominik Paprotny",
+                "orcid":"0000-0001-5090-8402"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"laurence.hawker@bristol.ac.uk",
+                "name":"Laurence Hawker",
+                "orcid":"0000-0002-8317-7084"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"M.Bondarenko@soton.ac.uk",
+                "name":"Maksym Bondarenko",
+                "orcid":"0000-0003-4958-6551"
+            },
+            {
+                "affiliations":[
+                    "Department of Social Statistics and Demography, University of Southampton, UK"
+                ],
+                "email":"J.D.Hilton@soton.ac.uk",
+                "name":"Jason Hilton",
+                "orcid":"0000-0001-9473-757X"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"n.tejedor-garavito@soton.ac.uk",
+                "name":"Natalia Tejedor Garavito",
+                "orcid":"0000-0002-1140-6263"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"evgeny.noi@bristol.ac.uk",
+                "name":"Evgeny Noi",
+                "orcid":"0000-0002-7914-1548"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"A.J.Tatem@soton.ac.uk",
+                "name":"Andrew Tatem",
+                "orcid":"0000-0002-7270-941X"
+            }
+        ],
+        "contact":"Dominik Paprotny (dominik.paprotny@pik-potsdam.de); Laurence Hawker (laurence.hawker@bristol.ac.uk)",
+        "dataset_category":[
+            "population"
+        ],
+        "further_info_url":"https://github.com/HORIZON-COMPASS/Exposure-and-vulnerability-modelling",
+        "institution_id":"PIK",
+        "license_id":"CC BY 4.0",
+        "mip_era":"CMIP6Plus",
+        "source_version":"0.2.0"
+    },
+    "PIK-vllo-0-2-0":{
+        "activity_id":"input4MIPs",
+        "authors":[
+            {
+                "affiliations":[
+                    "Research Department Transformation Pathways, Potsdam Institute for Climate Impact Research (PIK), Member of the Leibniz Association, Potsdam, Germany",
+                    "Institute of Marine and Environmental Sciences, University of Szczecin, Szczecin, Poland"
+                ],
+                "email":"dominik.paprotny@pik-potsdam.de",
+                "name":"Dominik Paprotny",
+                "orcid":"0000-0001-5090-8402"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"laurence.hawker@bristol.ac.uk",
+                "name":"Laurence Hawker",
+                "orcid":"0000-0002-8317-7084"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"M.Bondarenko@soton.ac.uk",
+                "name":"Maksym Bondarenko",
+                "orcid":"0000-0003-4958-6551"
+            },
+            {
+                "affiliations":[
+                    "Department of Social Statistics and Demography, University of Southampton, UK"
+                ],
+                "email":"J.D.Hilton@soton.ac.uk",
+                "name":"Jason Hilton",
+                "orcid":"0000-0001-9473-757X"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"n.tejedor-garavito@soton.ac.uk",
+                "name":"Natalia Tejedor Garavito",
+                "orcid":"0000-0002-1140-6263"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"evgeny.noi@bristol.ac.uk",
+                "name":"Evgeny Noi",
+                "orcid":"0000-0002-7914-1548"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"A.J.Tatem@soton.ac.uk",
+                "name":"Andrew Tatem",
+                "orcid":"0000-0002-7270-941X"
+            }
+        ],
+        "contact":"Dominik Paprotny (dominik.paprotny@pik-potsdam.de); Laurence Hawker (laurence.hawker@bristol.ac.uk)",
+        "dataset_category":[
+            "population"
+        ],
+        "further_info_url":"https://github.com/HORIZON-COMPASS/Exposure-and-vulnerability-modelling",
+        "institution_id":"PIK",
+        "license_id":"CC BY 4.0",
+        "mip_era":"CMIP6Plus",
+        "source_version":"0.2.0"
+    },
+    "PIK-vlho-0-2-0":{
+        "activity_id":"input4MIPs",
+        "authors":[
+            {
+                "affiliations":[
+                    "Research Department Transformation Pathways, Potsdam Institute for Climate Impact Research (PIK), Member of the Leibniz Association, Potsdam, Germany",
+                    "Institute of Marine and Environmental Sciences, University of Szczecin, Szczecin, Poland"
+                ],
+                "email":"dominik.paprotny@pik-potsdam.de",
+                "name":"Dominik Paprotny",
+                "orcid":"0000-0001-5090-8402"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"laurence.hawker@bristol.ac.uk",
+                "name":"Laurence Hawker",
+                "orcid":"0000-0002-8317-7084"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"M.Bondarenko@soton.ac.uk",
+                "name":"Maksym Bondarenko",
+                "orcid":"0000-0003-4958-6551"
+            },
+            {
+                "affiliations":[
+                    "Department of Social Statistics and Demography, University of Southampton, UK"
+                ],
+                "email":"J.D.Hilton@soton.ac.uk",
+                "name":"Jason Hilton",
+                "orcid":"0000-0001-9473-757X"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"n.tejedor-garavito@soton.ac.uk",
+                "name":"Natalia Tejedor Garavito",
+                "orcid":"0000-0002-1140-6263"
+            },
+            {
+                "affiliations":[
+                    "School of Geographical Sciences, University of Bristol, Bristol, UK",
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"evgeny.noi@bristol.ac.uk",
+                "name":"Evgeny Noi",
+                "orcid":"0000-0002-7914-1548"
+            },
+            {
+                "affiliations":[
+                    "WorldPop, University of Southampton, Southampton, UK"
+                ],
+                "email":"A.J.Tatem@soton.ac.uk",
+                "name":"Andrew Tatem",
+                "orcid":"0000-0002-7270-941X"
+            }
+        ],
+        "contact":"Dominik Paprotny (dominik.paprotny@pik-potsdam.de); Laurence Hawker (laurence.hawker@bristol.ac.uk)",
+        "dataset_category":[
+            "population"
+        ],
+        "further_info_url":"https://github.com/HORIZON-COMPASS/Exposure-and-vulnerability-modelling",
+        "institution_id":"PIK",
+        "license_id":"CC BY 4.0",
+        "mip_era":"CMIP6Plus",
+        "source_version":"0.2.0"
+    },
     "SOLARIS-HEPPA-CMIP-4-1":{
         "activity_id":"input4MIPs",
         "authors":[


### PR DESCRIPTION
## Description

Introduces improved historical (PIK-CMIP-1-0-1) and projections (PIK-*scenario*-1-0-0) of population density.
The improved data include revised WorldPop/FuturePop data, but keeps HYDE 3.2 as newer data were not obtained.
Also, the data include a fix of a calculation bug discovered in the 0.25 degree resolution files thanks to @slm7826 and @vnaik60 (https://github.com/PCMDI/input4MIPs_CVs/issues/362). The 0.5 degree data was not affected.

@durack1 @znicholls I have validated and uploaded the revised files to "PIK-2025-09-27" folder on the FTP.

## Checklist
 
Please confirm that this pull request has done the following:

- [ ] Data released on ESGF
- [ ] ESGF update pulled in here
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
- [ ] Did a new release after merging
