### PR TITLE
Update link description for CMIP7 dataset differences

### DIFF
--- a/docs/dataset-overviews/anthropogenic-slcf-co2-emissions.md
+++ b/docs/dataset-overviews/anthropogenic-slcf-co2-emissions.md
@@ -27,7 +27,7 @@ This data is derived from CEDS' aggregate emissions releases.
 <!--- Note that country totals in these summary files do not include international shipping or aircraft emissions, which are reported under the "global" iso. -->
 
 Full details on the dataset and all relevant links can be found on the [CEDS GitHub page](https://github.com/JGCRI/CEDS).
-A summary of differences between the CMIP7 and previous versions of the dataset can be found on https://github.com/JGCRI/CEDS/tree/master/documentation.
+A summary of differences between the CMIP7 and previous versions of the dataset can be found on the [CEDS GitHub documentation page](https://github.com/JGCRI/CEDS/tree/master/documentation).
 
 <!--- begin-cmip7-phases-source-ids -->
 <!--- Do not edit this section, it is automatically updated when the docs are built -->


### PR DESCRIPTION
Small edit so that the link to the CEDS Github documentation page is visible.

## Description

## Checklist

Please confirm that this pull request has done the following:

- [ ] Data released on ESGF
- [ ] ESGF update pulled in here
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
- [ ] Did a new release after merging
